### PR TITLE
Update setting-up-consumer.rst - AWS_S3 emphasize line fix

### DIFF
--- a/docs/setting-up-consumer.rst
+++ b/docs/setting-up-consumer.rst
@@ -408,7 +408,7 @@ Example Declaration:
 
 .. literalinclude:: ../examples/declarations/consumers/AWS_S3/aws_s3.json
     :language: json
-    :emphasize-lines: 12
+    :emphasize-lines: 13
 
 |
 


### PR DESCRIPTION
Wrong line was being emphasized, line 12 was only a }, line 13 was the line that should be emphasized.

#### What issues does this address?
Documentation issue I found.

#### What does this change do?
Fixes documentation to highlight the correct line in example code.

#### Where should the reviewer start?
There is only 1 line change to review.

#### Any background context?
This page is visible at:
https://clouddocs.f5.com/products/extensions/f5-telemetry-streaming/latest/setting-up-consumer.html
There it was observed the wrong line was being highlighted.
